### PR TITLE
Few more tests are added of wallet item transfer queries

### DIFF
--- a/src/fsdata/gql/graphql.ts
+++ b/src/fsdata/gql/graphql.ts
@@ -5097,6 +5097,7 @@ export type QueryFindWalletItemTransferByTransferSlugArgs = {
 
 
 export type QueryFindWalletItemTransferRecipientInfoByTransferSlugArgs = {
+  transferSecret: Scalars['String']['input'];
   transferSlug: Scalars['String']['input'];
 };
 
@@ -7193,6 +7194,11 @@ export type WalletItemTransfer = {
   notificationId?: Maybe<Scalars['ID']['output']>;
   recipientEmail?: Maybe<Scalars['String']['output']>;
   recipientFullName?: Maybe<Scalars['String']['output']>;
+  recipientPhoneNumber?: Maybe<Scalars['String']['output']>;
+  /** email | phoneNumber | link */
+  sendMethod?: Maybe<Scalars['String']['output']>;
+  /** i.e. WhatsApp, Signal, ... */
+  sendPlatform?: Maybe<Scalars['String']['output']>;
   /** Date this transfer was sent */
   sentAt?: Maybe<Scalars['DateTimeISO']['output']>;
   subjectText?: Maybe<Scalars['String']['output']>;
@@ -7224,6 +7230,11 @@ export type WalletItemTransferInput = {
   password?: InputMaybe<Scalars['String']['input']>;
   recipientEmail?: InputMaybe<Scalars['String']['input']>;
   recipientFullName?: InputMaybe<Scalars['String']['input']>;
+  recipientPhoneNumber?: InputMaybe<Scalars['String']['input']>;
+  /** email | phoneNumber | link */
+  sendMethod?: InputMaybe<Scalars['String']['input']>;
+  /** i.e. WhatsApp, Signal, ... */
+  sendPlatform?: InputMaybe<Scalars['String']['input']>;
   /** Date this transfer was sent */
   sentAt?: InputMaybe<Scalars['DateTimeISO']['input']>;
   subjectText?: InputMaybe<Scalars['String']['input']>;
@@ -7250,6 +7261,7 @@ export type WalletItemTransferRecipientInfo = {
   __typename?: 'WalletItemTransferRecipientInfo';
   brand?: Maybe<Brand>;
   product?: Maybe<GiftCardProduct>;
+  secretCheck?: Maybe<Scalars['String']['output']>;
   walletItem: WalletItem;
   walletItemTransfer: WalletItemTransfer;
 };

--- a/src/fsdata/graffle/modules/schema-driven-data-map.ts
+++ b/src/fsdata/graffle/modules/schema-driven-data-map.ts
@@ -1851,12 +1851,15 @@ const WalletItemTransferInput: $$Utilities.SchemaDrivenDataMap.InputObject = {
     walletItemId: {},
     notificationId: {},
     recipientEmail: {},
+    recipientPhoneNumber: {},
     recipientFullName: {},
     subjectText: {},
     messageText: {},
     transferSlug: {},
     transferSecret: {},
     password: {},
+    sendMethod: {},
+    sendPlatform: {},
     sentAt: {
       nt: DateTimeISO,
     },
@@ -6413,6 +6416,7 @@ const WalletItemTransferRecipientInfo: $$Utilities.SchemaDrivenDataMap.OutputObj
     product: {
       // nt: GiftCardProduct, <-- Assigned later to avoid potential circular dependency.
     },
+    secretCheck: {},
   },
 };
 
@@ -6441,10 +6445,13 @@ const WalletItemTransfer: $$Utilities.SchemaDrivenDataMap.OutputObject = {
     walletItemId: {},
     notificationId: {},
     recipientEmail: {},
+    recipientPhoneNumber: {},
     recipientFullName: {},
     subjectText: {},
     messageText: {},
     transferSlug: {},
+    sendMethod: {},
+    sendPlatform: {},
     sentAt: {
       nt: DateTimeISO,
     },
@@ -8756,6 +8763,10 @@ const Query: $$Utilities.SchemaDrivenDataMap.OutputObject = {
     },
     findWalletItemTransferRecipientInfoByTransferSlug: {
       a: {
+        transferSecret: {
+          nt: String,
+          it: [1],
+        },
         transferSlug: {
           nt: String,
           it: [1],

--- a/src/fsdata/graffle/modules/schema.ts
+++ b/src/fsdata/graffle/modules/schema.ts
@@ -1567,6 +1567,12 @@ export namespace Schema {
       kind: 'OutputField';
       name: 'findWalletItemTransferRecipientInfoByTransferSlug';
       arguments: {
+        transferSecret: {
+          kind: 'InputField';
+          name: 'transferSecret';
+          inlineType: [1];
+          namedType: $$NamedTypes.$$String;
+        };
         transferSlug: {
           kind: 'InputField';
           name: 'transferSlug';
@@ -21718,6 +21724,7 @@ export namespace Schema {
       walletItemTransfer: WalletItemTransferRecipientInfo.walletItemTransfer;
       brand: WalletItemTransferRecipientInfo.brand;
       product: WalletItemTransferRecipientInfo.product;
+      secretCheck: WalletItemTransferRecipientInfo.secretCheck;
     };
   }
 
@@ -21764,6 +21771,14 @@ export namespace Schema {
       inlineType: [0];
       namedType: $$NamedTypes.$$GiftCardProduct;
     }
+
+    export interface secretCheck {
+      kind: 'OutputField';
+      name: 'secretCheck';
+      arguments: {};
+      inlineType: [0];
+      namedType: $$NamedTypes.$$String;
+    }
   }
 
   //                                         WalletItemTransfer
@@ -21788,10 +21803,13 @@ export namespace Schema {
       walletItemId: WalletItemTransfer.walletItemId;
       notificationId: WalletItemTransfer.notificationId;
       recipientEmail: WalletItemTransfer.recipientEmail;
+      recipientPhoneNumber: WalletItemTransfer.recipientPhoneNumber;
       recipientFullName: WalletItemTransfer.recipientFullName;
       subjectText: WalletItemTransfer.subjectText;
       messageText: WalletItemTransfer.messageText;
       transferSlug: WalletItemTransfer.transferSlug;
+      sendMethod: WalletItemTransfer.sendMethod;
+      sendPlatform: WalletItemTransfer.sendPlatform;
       sentAt: WalletItemTransfer.sentAt;
       acceptedAt: WalletItemTransfer.acceptedAt;
       declinedAt: WalletItemTransfer.declinedAt;
@@ -21916,6 +21934,14 @@ export namespace Schema {
       namedType: $$NamedTypes.$$String;
     }
 
+    export interface recipientPhoneNumber {
+      kind: 'OutputField';
+      name: 'recipientPhoneNumber';
+      arguments: {};
+      inlineType: [0];
+      namedType: $$NamedTypes.$$String;
+    }
+
     export interface recipientFullName {
       kind: 'OutputField';
       name: 'recipientFullName';
@@ -21943,6 +21969,28 @@ export namespace Schema {
     export interface transferSlug {
       kind: 'OutputField';
       name: 'transferSlug';
+      arguments: {};
+      inlineType: [0];
+      namedType: $$NamedTypes.$$String;
+    }
+
+    /**
+     * email | phoneNumber | link
+     */
+    export interface sendMethod {
+      kind: 'OutputField';
+      name: 'sendMethod';
+      arguments: {};
+      inlineType: [0];
+      namedType: $$NamedTypes.$$String;
+    }
+
+    /**
+     * i.e. WhatsApp, Signal, ...
+     */
+    export interface sendPlatform {
+      kind: 'OutputField';
+      name: 'sendPlatform';
       arguments: {};
       inlineType: [0];
       namedType: $$NamedTypes.$$String;
@@ -35709,12 +35757,15 @@ export namespace Schema {
       walletItemId: WalletItemTransferInput.walletItemId;
       notificationId: WalletItemTransferInput.notificationId;
       recipientEmail: WalletItemTransferInput.recipientEmail;
+      recipientPhoneNumber: WalletItemTransferInput.recipientPhoneNumber;
       recipientFullName: WalletItemTransferInput.recipientFullName;
       subjectText: WalletItemTransferInput.subjectText;
       messageText: WalletItemTransferInput.messageText;
       transferSlug: WalletItemTransferInput.transferSlug;
       transferSecret: WalletItemTransferInput.transferSecret;
       password: WalletItemTransferInput.password;
+      sendMethod: WalletItemTransferInput.sendMethod;
+      sendPlatform: WalletItemTransferInput.sendPlatform;
       sentAt: WalletItemTransferInput.sentAt;
       acceptedAt: WalletItemTransferInput.acceptedAt;
       declinedAt: WalletItemTransferInput.declinedAt;
@@ -35815,6 +35866,13 @@ export namespace Schema {
       namedType: $$NamedTypes.$$String;
     }
 
+    export interface recipientPhoneNumber {
+      kind: 'InputField';
+      name: 'recipientPhoneNumber';
+      inlineType: [0];
+      namedType: $$NamedTypes.$$String;
+    }
+
     export interface recipientFullName {
       kind: 'InputField';
       name: 'recipientFullName';
@@ -35853,6 +35911,26 @@ export namespace Schema {
     export interface password {
       kind: 'InputField';
       name: 'password';
+      inlineType: [0];
+      namedType: $$NamedTypes.$$String;
+    }
+
+    /**
+     * email | phoneNumber | link
+     */
+    export interface sendMethod {
+      kind: 'InputField';
+      name: 'sendMethod';
+      inlineType: [0];
+      namedType: $$NamedTypes.$$String;
+    }
+
+    /**
+     * i.e. WhatsApp, Signal, ...
+     */
+    export interface sendPlatform {
+      kind: 'InputField';
+      name: 'sendPlatform';
       inlineType: [0];
       namedType: $$NamedTypes.$$String;
     }

--- a/src/fsdata/operations/walletItemTransfer/findWalletItemTransferRecipientInfoByTransferSlug.ts
+++ b/src/fsdata/operations/walletItemTransfer/findWalletItemTransferRecipientInfoByTransferSlug.ts
@@ -18,6 +18,7 @@ type ResponseDataType = {
 
 const findWalletItemTransferRecipientInfoByTransferSlug = async (
   transferSlug: string,
+  transferSecret?: string | null,
 ): Promise<QueryResult<WalletItemTransferRecipientInfo>> => {
   try {
     if (!libData.isInitialized()) {
@@ -28,6 +29,7 @@ const findWalletItemTransferRecipientInfoByTransferSlug = async (
     const client = graffleClientStore.get();
     const args: QueryFindWalletItemTransferRecipientInfoByTransferSlugArgs = {
       transferSlug,
+      transferSecret,
     };
 
     const response: ResponseDataType = await client.query.findWalletItemTransferRecipientInfoByTransferSlug({

--- a/src/models/BgChannel.ts
+++ b/src/models/BgChannel.ts
@@ -14,6 +14,7 @@ export class BgChannel extends BaseModel {
   public userIds?: string[] | null;
   public otherUserId?: string | null;
   declare public metadata?: ChannelMetadata | null;
+  public syncedToAnalyticsAt?: string | null;
   public pausedAt?: string | null;
   public pausedBy?: string | null;
   public suspendedAt?: string | null;
@@ -55,6 +56,9 @@ export class BgChannel extends BaseModel {
       }
       if (attributes.metadata !== undefined) {
         this.metadata = attributes.metadata;
+      }
+      if (attributes.syncedToAnalyticsAt !== undefined && attributes.syncedToAnalyticsAt !== '') {
+        this.syncedToAnalyticsAt = attributes.syncedToAnalyticsAt;
       }
       if (attributes.pausedAt !== undefined && attributes.pausedAt !== '') {
         this.pausedAt = attributes.pausedAt;

--- a/src/models/BgChannelInvitation.ts
+++ b/src/models/BgChannelInvitation.ts
@@ -14,6 +14,7 @@ export class BgChannelInvitation extends BaseModel {
   public dismissedFromInboxByRecipientAt?: string | null;
   public readByRecipientAt?: string | null;
   public status: ChannelInvitationStatus = ChannelInvitationStatus.unset;
+  public syncedToAnalyticsAt?: string | null;
   public suspendedAt?: string | null;
   public suspendedBy?: string | null;
   public userSearchId?: string | null;
@@ -56,6 +57,9 @@ export class BgChannelInvitation extends BaseModel {
       }
       if (attributes.status !== undefined) {
         this.status = attributes.status;
+      }
+      if (attributes.syncedToAnalyticsAt !== undefined && attributes.syncedToAnalyticsAt !== '') {
+        this.syncedToAnalyticsAt = attributes.syncedToAnalyticsAt;
       }
       if (attributes.suspendedAt !== undefined && attributes.suspendedAt !== '') {
         this.suspendedAt = attributes.suspendedAt;

--- a/src/models/WalletItemTransfer.ts
+++ b/src/models/WalletItemTransfer.ts
@@ -5,12 +5,15 @@ export class WalletItemTransfer extends BaseModel {
   public walletItemId = '';
   public notificationId?: string | null;
   public recipientEmail?: string | null;
+  public recipientPhoneNumber?: string | null;
   public recipientFullName?: string | null;
   public subjectText?: string | null;
   public messageText?: string | null;
   public transferSlug?: string | null;
   public transferSecret?: string | null;
   public passwordHash?: string | null;
+  public sendMethod?: string | null;
+  public sendPlatform?: string | null;
   public sentAt?: string | null;
   public acceptedAt?: string | null;
   public declinedAt?: string | null;
@@ -32,6 +35,9 @@ export class WalletItemTransfer extends BaseModel {
       if (attributes.recipientEmail !== undefined) {
         this.recipientEmail = attributes.recipientEmail;
       }
+      if (attributes.recipientPhoneNumber !== undefined) {
+        this.recipientPhoneNumber = attributes.recipientPhoneNumber;
+      }
       if (attributes.recipientFullName !== undefined) {
         this.recipientFullName = attributes.recipientFullName;
       }
@@ -49,6 +55,12 @@ export class WalletItemTransfer extends BaseModel {
       }
       if (attributes.passwordHash !== undefined) {
         this.passwordHash = attributes.passwordHash;
+      }
+      if (attributes.sendMethod !== undefined) {
+        this.sendMethod = attributes.sendMethod;
+      }
+      if (attributes.sendPlatform !== undefined) {
+        this.sendPlatform = attributes.sendPlatform;
       }
       if (attributes.sentAt !== undefined && attributes.sentAt !== '') {
         this.sentAt = attributes.sentAt;

--- a/src/models/WalletItemTransferRecipientInfo.ts
+++ b/src/models/WalletItemTransferRecipientInfo.ts
@@ -10,6 +10,7 @@ export class WalletItemTransferRecipientInfo extends BaseModel {
   public walletItemTransfer: WalletItemTransfer = new WalletItemTransfer();
   public brand?: Brand | null;
   public product?: GiftCardProduct | null;
+  public secretCheck?: string | null;
   // @bg-codegen:/class.attr >>Note: Code is generated between these markers<<
 
   constructor(attributes?: Partial<WalletItemTransferRecipientInfo>) {
@@ -28,6 +29,9 @@ export class WalletItemTransferRecipientInfo extends BaseModel {
       }
       if (attributes.product !== undefined) {
         this.product = attributes.product;
+      }
+      if (attributes.secretCheck !== undefined) {
+        this.secretCheck = attributes.secretCheck;
       }
       // @bg-codegen:/class.const.attr >>Note: Code is generated between these markers<<
     }

--- a/src/models/schema/WalletItemTransferRecipientInfoSchema.ts
+++ b/src/models/schema/WalletItemTransferRecipientInfoSchema.ts
@@ -1,5 +1,5 @@
-export const WalletItemTransferRecipientInfoInfoSchema = {
-  title: 'WalletItemTransferRecipientInfoInfo',
+export const WalletItemTransferRecipientInfoSchema = {
+  title: 'WalletItemTransferRecipientInfo',
   version: 0,
   primaryKey: 'id',
   type: 'object',
@@ -286,6 +286,10 @@ export const WalletItemTransferRecipientInfoInfoSchema = {
           type: 'string',
           nullable: true,
         },
+        recipientPhoneNumber: {
+          type: 'string',
+          nullable: true,
+        },
         recipientFullName: {
           type: 'string',
           nullable: true,
@@ -308,6 +312,16 @@ export const WalletItemTransferRecipientInfoInfoSchema = {
         },
         passwordHash: {
           type: 'string',
+          nullable: true,
+        },
+        sendMethod: {
+          type: 'string',
+          description: 'email | phoneNumber | link',
+          nullable: true,
+        },
+        sendPlatform: {
+          type: 'string',
+          description: 'i.e. WhatsApp, Signal, ...',
           nullable: true,
         },
         sentAt: {
@@ -585,6 +599,10 @@ export const WalletItemTransferRecipientInfoInfoSchema = {
           nullable: true,
         },
       },
+      nullable: true,
+    },
+    secretCheck: {
+      type: 'string',
       nullable: true,
     },
   },

--- a/src/models/schema/channelInvitationSchema.ts
+++ b/src/models/schema/channelInvitationSchema.ts
@@ -101,6 +101,11 @@ export const ChannelInvitationSchema = {
       type: 'string',
       enum: ['created', 'accepted', 'declined', 'unset'],
     },
+    syncedToAnalyticsAt: {
+      type: 'string',
+      format: 'date-time',
+      nullable: true,
+    },
     suspendedAt: {
       type: 'string',
       format: 'date-time',

--- a/src/models/schema/channelMessageSchema.ts
+++ b/src/models/schema/channelMessageSchema.ts
@@ -118,6 +118,11 @@ export const ChannelMessageSchema = {
       format: 'date-time',
       nullable: true,
     },
+    syncedToAnalyticsAt: {
+      type: 'string',
+      format: 'date-time',
+      nullable: true,
+    },
     suspendedAt: {
       type: 'string',
       format: 'date-time',

--- a/src/models/schema/channelSchema.ts
+++ b/src/models/schema/channelSchema.ts
@@ -114,6 +114,11 @@ export const ChannelSchema = {
       maxLength: 32,
       nullable: true,
     },
+    syncedToAnalyticsAt: {
+      type: 'string',
+      format: 'date-time',
+      nullable: true,
+    },
     pausedAt: {
       type: 'string',
       format: 'date-time',

--- a/src/models/schema/walletItemTransferSchema.ts
+++ b/src/models/schema/walletItemTransferSchema.ts
@@ -65,6 +65,10 @@ export const WalletItemTransferSchema = {
       type: 'string',
       nullable: true,
     },
+    recipientPhoneNumber: {
+      type: 'string',
+      nullable: true,
+    },
     recipientFullName: {
       type: 'string',
       nullable: true,
@@ -87,6 +91,16 @@ export const WalletItemTransferSchema = {
     },
     passwordHash: {
       type: 'string',
+      nullable: true,
+    },
+    sendMethod: {
+      type: 'string',
+      description: 'email | phoneNumber | link',
+      nullable: true,
+    },
+    sendPlatform: {
+      type: 'string',
+      description: 'i.e. WhatsApp, Signal, ...',
       nullable: true,
     },
     sentAt: {

--- a/src/operations/walletItemTransfer/findWalletItemTransferRecipientInfoByTransferSlug.ts
+++ b/src/operations/walletItemTransfer/findWalletItemTransferRecipientInfoByTransferSlug.ts
@@ -7,6 +7,7 @@ import { QueryResult } from '../../types/QueryResult.js';
 
 const findWalletItemTransferRecipientInfoByTransferSlug = async (
   transferSlug: string,
+  transferSecret?: string | null,
 ): Promise<QueryResult<WalletItemTransferRecipientInfo>> => {
   try {
     if (!libData.isInitialized()) {
@@ -16,6 +17,7 @@ const findWalletItemTransferRecipientInfoByTransferSlug = async (
 
     const response = await fsdata.walletItemTransfer.findWalletItemTransferRecipientInfoByTransferSlug(
       transferSlug,
+      transferSecret,
     );
 
     if (!response.error && response.object && response.object.brand) {

--- a/src/test/operations/walletItemTransfer/findWalletItemTransferById.spec.ts
+++ b/src/test/operations/walletItemTransfer/findWalletItemTransferById.spec.ts
@@ -16,7 +16,7 @@ import { createWalletItemTransferSpecHelper } from '../../helpers/walletItemTran
 describe('operations.walletItemTransfer.findWalletItemTransferById', () => {
   let client: BgNodeClient;
   let myUser: MyUser;
-  let walletItemTransfers: WalletItemTransfer[] = [];
+  const walletItemTransfers: WalletItemTransfer[] = [];
   let walletItemTransferId: string;
 
   beforeAll(async () => {

--- a/src/test/operations/walletItemTransfer/findWalletItemTransferById.spec.ts
+++ b/src/test/operations/walletItemTransfer/findWalletItemTransferById.spec.ts
@@ -16,7 +16,7 @@ import { createWalletItemTransferSpecHelper } from '../../helpers/walletItemTran
 describe('operations.walletItemTransfer.findWalletItemTransferById', () => {
   let client: BgNodeClient;
   let myUser: MyUser;
-  let walletItemTransfers: WalletItemTransfer[];
+  let walletItemTransfers: WalletItemTransfer[] = [];
   let walletItemTransferId: string;
 
   beforeAll(async () => {
@@ -43,7 +43,7 @@ describe('operations.walletItemTransfer.findWalletItemTransferById', () => {
       const response = await createWalletItemTransferSpecHelper({
         walletItemId: item.id,
       }, client);
-      walletItemTransfers = [...(walletItemTransfers || []), response.walletItemTransfer];
+      walletItemTransfers.push(response.walletItemTransfer);
     }
 
     walletItemTransferId = chance.pickone(walletItemTransfers).id;

--- a/src/test/operations/walletItemTransfer/findWalletItemTransferById.spec.ts
+++ b/src/test/operations/walletItemTransfer/findWalletItemTransferById.spec.ts
@@ -1,0 +1,59 @@
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+
+import { BgNodeClient } from '../../../BgNodeClient.js';
+import chance from '../../../helpers/chance.js';
+import { WalletItemTransfer } from '../../../index.js';
+import { MyUser } from '../../../models/MyUser.js';
+import findWalletItemTransferById from '../../../operations/walletItemTransfer/findWalletItemTransferById.js';
+import clientStore from '../../helpers/clientStore.js';
+import { createPurchaseOrderSpecHelper } from '../../helpers/purchaseOrder/createPurchaseOrder.specHelper.js';
+import { deleteMyUserSpecHelper } from '../../helpers/user/deleteMyUser.specHelper.js';
+import { signMeUpSpecHelper } from '../../helpers/user/signMeUp.specHelper.js';
+import { findWalletItemsSpecHelper } from '../../helpers/walletItem/findWalletItems.specHelper.js';
+import { createWalletItemTransferSpecHelper } from '../../helpers/walletItemTransfer/createWalletItemTransfer.specHelper.js';
+
+
+describe('operations.walletItemTransfer.findWalletItemTransferById', () => {
+  let client: BgNodeClient;
+  let myUser: MyUser;
+  let walletItemTransfers: WalletItemTransfer[];
+  let walletItemTransferId: string;
+
+  beforeAll(async () => {
+    client = await clientStore.getTestClient();
+    myUser = await signMeUpSpecHelper(undefined, false, client);
+  });
+
+  afterAll(async () => {
+    await deleteMyUserSpecHelper(client);
+  });
+
+  test('should find the created wallet item transfer', async () => {
+    const itemCount = chance.integer({ min: 2, max: 4 });
+    await createPurchaseOrderSpecHelper(
+      {},
+      itemCount,
+      [],
+      client,
+    );
+
+    const walletItems = await findWalletItemsSpecHelper(client, myUser, itemCount);
+
+    for (const item of walletItems) {
+      const response = await createWalletItemTransferSpecHelper({
+        walletItemId: item.id,
+      }, client);
+      walletItemTransfers = [...(walletItemTransfers || []), response.walletItemTransfer];
+    }
+
+    walletItemTransferId = chance.pickone(walletItemTransfers).id;
+
+    const result = await findWalletItemTransferById(
+      walletItemTransferId,
+      {},
+    );
+    expect(result.error).toBeUndefined();
+    expect(result.object).toBeTruthy();
+    expect(result.object.id).toBe(walletItemTransferId);
+  }, 10000);
+});

--- a/src/test/operations/walletItemTransfer/findWalletItemTransferRecipientInfoByTransferSlug.spec.ts
+++ b/src/test/operations/walletItemTransfer/findWalletItemTransferRecipientInfoByTransferSlug.spec.ts
@@ -1,0 +1,62 @@
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+
+import { BgNodeClient } from '../../../BgNodeClient.js';
+import chance from '../../../helpers/chance.js';
+import { WalletItemTransfer } from '../../../index.js';
+import { MyUser } from '../../../models/MyUser.js';
+import findWalletItemTransferRecipientInfoByTransferSlug from '../../../operations/walletItemTransfer/findWalletItemTransferRecipientInfoByTransferSlug.js';
+import clientStore from '../../helpers/clientStore.js';
+import { createPurchaseOrderSpecHelper } from '../../helpers/purchaseOrder/createPurchaseOrder.specHelper.js';
+import { deleteMyUserSpecHelper } from '../../helpers/user/deleteMyUser.specHelper.js';
+import { signMeUpSpecHelper } from '../../helpers/user/signMeUp.specHelper.js';
+import { findWalletItemsSpecHelper } from '../../helpers/walletItem/findWalletItems.specHelper.js';
+import { createWalletItemTransferSpecHelper } from '../../helpers/walletItemTransfer/createWalletItemTransfer.specHelper.js';
+
+
+describe('operations.walletItemTransfer.findWalletItemTransferRecipientInfoByTransferSlug', () => {
+  let client: BgNodeClient;
+  let myUser: MyUser;
+  let walletItemTransfers: WalletItemTransfer[];
+  let walletItemTransfer: WalletItemTransfer;
+
+  beforeAll(async () => {
+    client = await clientStore.getTestClient();
+    myUser = await signMeUpSpecHelper(undefined, false, client);
+  });
+
+  afterAll(async () => {
+    await deleteMyUserSpecHelper(client);
+  });
+
+  test('should find the created wallet item transfer', async () => {
+    const itemCount = chance.integer({ min: 2, max: 4 });
+    await createPurchaseOrderSpecHelper(
+      {},
+      itemCount,
+      [],
+      client,
+    );
+
+    const walletItems = await findWalletItemsSpecHelper(client, myUser, itemCount);
+
+    for (const item of walletItems) {
+      const response = await createWalletItemTransferSpecHelper({
+        walletItemId: item.id,
+      }, client);
+      walletItemTransfers = [...(walletItemTransfers || []), response.walletItemTransfer];
+    }
+
+    walletItemTransfer = chance.pickone(walletItemTransfers);
+
+    const result = await findWalletItemTransferRecipientInfoByTransferSlug(
+      walletItemTransfer.transferSlug,
+    );
+    expect(result.error).toBeUndefined();
+    expect(result.object).toBeTruthy();
+    expect(result.object.walletItem).toBeTruthy();
+    expect(result.object.product).toBeTruthy();
+    expect(result.object.brand).toBeTruthy();
+    expect(result.object.walletItemTransfer.transferSlug).toBe(walletItemTransfer.transferSlug);
+    expect(result.object.walletItemTransfer.transferSecret).toBe(walletItemTransfer.transferSecret);
+  }, 10000);
+});

--- a/src/test/operations/walletItemTransfer/findWalletItemTransferRecipientInfoByTransferSlug.spec.ts
+++ b/src/test/operations/walletItemTransfer/findWalletItemTransferRecipientInfoByTransferSlug.spec.ts
@@ -16,7 +16,7 @@ import { createWalletItemTransferSpecHelper } from '../../helpers/walletItemTran
 describe('operations.walletItemTransfer.findWalletItemTransferRecipientInfoByTransferSlug', () => {
   let client: BgNodeClient;
   let myUser: MyUser;
-  let walletItemTransfers: WalletItemTransfer[] = [];
+  const walletItemTransfers: WalletItemTransfer[] = [];
   let walletItemTransfer: WalletItemTransfer;
 
   beforeAll(async () => {

--- a/src/test/operations/walletItemTransfer/findWalletItemTransferRecipientInfoByTransferSlug.spec.ts
+++ b/src/test/operations/walletItemTransfer/findWalletItemTransferRecipientInfoByTransferSlug.spec.ts
@@ -16,7 +16,7 @@ import { createWalletItemTransferSpecHelper } from '../../helpers/walletItemTran
 describe('operations.walletItemTransfer.findWalletItemTransferRecipientInfoByTransferSlug', () => {
   let client: BgNodeClient;
   let myUser: MyUser;
-  let walletItemTransfers: WalletItemTransfer[];
+  let walletItemTransfers: WalletItemTransfer[] = [];
   let walletItemTransfer: WalletItemTransfer;
 
   beforeAll(async () => {
@@ -43,7 +43,7 @@ describe('operations.walletItemTransfer.findWalletItemTransferRecipientInfoByTra
       const response = await createWalletItemTransferSpecHelper({
         walletItemId: item.id,
       }, client);
-      walletItemTransfers = [...(walletItemTransfers || []), response.walletItemTransfer];
+      walletItemTransfers.push(response.walletItemTransfer);
     }
 
     walletItemTransfer = chance.pickone(walletItemTransfers);

--- a/src/test/operations/walletItemTransfer/updateWalletItemTransfer.spec.ts
+++ b/src/test/operations/walletItemTransfer/updateWalletItemTransfer.spec.ts
@@ -1,0 +1,101 @@
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+
+import { BgNodeClient } from '../../../BgNodeClient.js';
+import chance from '../../../helpers/chance.js';
+import { MyUser } from '../../../models/MyUser.js';
+import { WalletItemTransfer } from '../../../models/WalletItemTransfer.js';
+import updateWalletItemTransfer from '../../../operations/walletItemTransfer/updateWalletItemTransfer.js';
+import clientStore from '../../helpers/clientStore.js';
+import { createPurchaseOrderSpecHelper } from '../../helpers/purchaseOrder/createPurchaseOrder.specHelper.js';
+import { deleteMyUserSpecHelper } from '../../helpers/user/deleteMyUser.specHelper.js';
+import { signMeUpSpecHelper } from '../../helpers/user/signMeUp.specHelper.js';
+import { findWalletItemsSpecHelper } from '../../helpers/walletItem/findWalletItems.specHelper.js';
+import { createWalletItemTransferSpecHelper } from '../../helpers/walletItemTransfer/createWalletItemTransfer.specHelper.js';
+
+describe('operations.walletItemTransfer.updateWalletItemTransfer', () => {
+  let client: BgNodeClient;
+  let myUser: MyUser;
+  let walletItemTransfer: WalletItemTransfer;
+
+  beforeAll(async () => {
+    client = await clientStore.getTestClient();
+    myUser = await signMeUpSpecHelper(undefined, false, client);
+  });
+
+  afterAll(async () => {
+    await deleteMyUserSpecHelper(client);
+  });
+
+  test('should update wallet item transfer properties', async () => {
+    const itemCount = 1;
+    await createPurchaseOrderSpecHelper(
+      {},
+      itemCount,
+      [],
+      client,
+    );
+
+    const walletItems = await findWalletItemsSpecHelper(client, myUser, itemCount);
+    const walletItem = walletItems[0];
+
+    const { walletItemTransfer: createdTransfer } = await createWalletItemTransferSpecHelper({
+      walletItemId: walletItem.id,
+    }, client);
+
+    walletItemTransfer = createdTransfer;
+
+    // Update the wallet item transfer
+    const newRecipientName = chance.name();
+    const newRecipientEmail = chance.email();
+    const newMessageText = chance.sentence();
+
+    const updateChanges: Partial<WalletItemTransfer> = {
+      id: walletItemTransfer.id,
+      recipientFullName: newRecipientName,
+      recipientEmail: newRecipientEmail,
+      messageText: newMessageText,
+    };
+
+    const result = await updateWalletItemTransfer(updateChanges);
+
+    expect(result.error).toBeUndefined();
+    expect(result.object).toBeTruthy();
+    expect(result.object.id).toBe(walletItemTransfer.id);
+    expect(result.object.recipientFullName).toBe(newRecipientName);
+    expect(result.object.recipientEmail).toBe(newRecipientEmail);
+    expect(result.object.messageText).toBe(newMessageText);
+    expect(result.object.walletItemId).toBe(walletItem.id);
+  }, 10000);
+
+  test('should handle partial updates', async () => {
+    // Only update the message text
+    const newMessageText = chance.sentence();
+
+    const updateChanges: Partial<WalletItemTransfer> = {
+      id: walletItemTransfer.id,
+      messageText: newMessageText,
+    };
+
+    const result = await updateWalletItemTransfer(updateChanges);
+
+    expect(result.error).toBeUndefined();
+    expect(result.object).toBeTruthy();
+    expect(result.object.id).toBe(walletItemTransfer.id);
+    expect(result.object.messageText).toBe(newMessageText);
+    // Other properties should remain unchanged
+    expect(result.object.walletItemId).toBe(walletItemTransfer.walletItemId);
+  }, 10000);
+
+  test('should return error for invalid id', async () => {
+    const invalidId = chance.guid();
+    const updateChanges: Partial<WalletItemTransfer> = {
+      id: invalidId,
+      messageText: chance.sentence(),
+    };
+
+    const result = await updateWalletItemTransfer(updateChanges);
+
+    expect(result.error).toBeDefined();
+    expect(result.object).toBeUndefined();
+  }, 10000);
+});

--- a/src/test/operations/walletItemTransfer/updateWalletItemTransferPassword.spec.ts
+++ b/src/test/operations/walletItemTransfer/updateWalletItemTransferPassword.spec.ts
@@ -75,7 +75,7 @@ describe('operations.walletItemTransfer.updateWalletItemTransferPassword', () =>
       password,
     );
 
-    expect(result.serviceRequest.errorCode).toEqual('invalidInput');
+    expect(result.serviceRequest?.errorCode).toEqual('invalidInput');
   }, 10000);
 
   test('should return error for invalid transfer secret', async () => {
@@ -88,33 +88,6 @@ describe('operations.walletItemTransfer.updateWalletItemTransferPassword', () =>
       password,
     );
 
-    expect(result.serviceRequest.errorCode).toEqual('invalidInput');
+    expect(result.serviceRequest?.errorCode).toEqual('invalidInput');
   }, 10000);
-
-  test('should handle empty password', async () => {
-    const emptyPassword = '';
-
-    const result = await updateWalletItemTransferPassword(
-      transferSlug,
-      transferSecret,
-      emptyPassword,
-    );
-
-    // This might succeed or fail depending on business rules
-    // Adjust expectation based on actual behavior
-    expect(result).toBeTruthy();
-  }, 10000);
-
-  test('should handle special characters in password', async () => {
-    const specialPassword = 'Test@123!';
-
-    const result = await updateWalletItemTransferPassword(
-      transferSlug,
-      transferSecret,
-      specialPassword,
-    );
-
-    expect(result.error).toBeUndefined();
-    expect(result.serviceRequest).toBeTruthy();
-  }, 15000);
 });

--- a/src/test/operations/walletItemTransfer/updateWalletItemTransferPassword.spec.ts
+++ b/src/test/operations/walletItemTransfer/updateWalletItemTransferPassword.spec.ts
@@ -1,0 +1,120 @@
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+
+import { BgNodeClient } from '../../../BgNodeClient.js';
+import chance from '../../../helpers/chance.js';
+import { MyUser } from '../../../models/MyUser.js';
+import updateWalletItemTransferPassword from '../../../operations/walletItemTransfer/updateWalletItemTransferPassword.js';
+import clientStore from '../../helpers/clientStore.js';
+import { createPurchaseOrderSpecHelper } from '../../helpers/purchaseOrder/createPurchaseOrder.specHelper.js';
+import { deleteMyUserSpecHelper } from '../../helpers/user/deleteMyUser.specHelper.js';
+import { signMeUpSpecHelper } from '../../helpers/user/signMeUp.specHelper.js';
+import { findWalletItemsSpecHelper } from '../../helpers/walletItem/findWalletItems.specHelper.js';
+import { createWalletItemTransferSpecHelper } from '../../helpers/walletItemTransfer/createWalletItemTransfer.specHelper.js';
+
+describe('operations.walletItemTransfer.updateWalletItemTransferPassword', () => {
+  let client: BgNodeClient;
+  let myUser: MyUser;
+  let transferSecret: string;
+  let transferSlug: string;
+
+  beforeAll(async () => {
+    client = await clientStore.getTestClient();
+    myUser = await signMeUpSpecHelper(undefined, false, client);
+    transferSlug = chance.guid();
+    transferSecret = chance.integer({ min: 100000, max: 999999 }).toString();
+  });
+
+  afterAll(async () => {
+    await deleteMyUserSpecHelper(client);
+  });
+
+  test('should update wallet item transfer password successfully', async () => {
+    const itemCount = 1;
+    await createPurchaseOrderSpecHelper(
+      {},
+      itemCount,
+      [],
+      client,
+    );
+
+    const walletItems = await findWalletItemsSpecHelper(client, myUser, itemCount);
+    const walletItem = walletItems[0];
+
+    await createWalletItemTransferSpecHelper({
+      walletItemId: walletItem.id,
+      transferSlug,
+      transferSecret,
+      recipientFullName: chance.name(),
+      recipientEmail: chance.email(),
+      messageText: chance.sentence(),
+    }, client);
+
+
+    // Update the password
+    const newPassword = chance.string({ length: 8, alpha: true, numeric: true });
+
+    const result = await updateWalletItemTransferPassword(
+      transferSlug,
+      transferSecret,
+      newPassword,
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.serviceRequest).toBeTruthy();
+    expect(result.serviceRequest?.finishedAt).toBeTruthy();
+  }, 15000);
+
+  test('should return error for invalid transfer slug', async () => {
+    const invalidSlug = chance.guid();
+    const invalidSecret = chance.string({ length: 6, numeric: true });
+    const password = chance.string({ length: 8, alpha: true, numeric: true });
+
+    const result = await updateWalletItemTransferPassword(
+      invalidSlug,
+      invalidSecret,
+      password,
+    );
+
+    expect(result.serviceRequest.errorCode).toEqual('invalidInput');
+  }, 10000);
+
+  test('should return error for invalid transfer secret', async () => {
+    const invalidSecret = chance.string({ length: 6, numeric: true });
+    const password = chance.string({ length: 8, alpha: true, numeric: true });
+
+    const result = await updateWalletItemTransferPassword(
+      transferSlug,
+      invalidSecret,
+      password,
+    );
+
+    expect(result.serviceRequest.errorCode).toEqual('invalidInput');
+  }, 10000);
+
+  test('should handle empty password', async () => {
+    const emptyPassword = '';
+
+    const result = await updateWalletItemTransferPassword(
+      transferSlug,
+      transferSecret,
+      emptyPassword,
+    );
+
+    // This might succeed or fail depending on business rules
+    // Adjust expectation based on actual behavior
+    expect(result).toBeTruthy();
+  }, 10000);
+
+  test('should handle special characters in password', async () => {
+    const specialPassword = 'Test@123!';
+
+    const result = await updateWalletItemTransferPassword(
+      transferSlug,
+      transferSecret,
+      specialPassword,
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.serviceRequest).toBeTruthy();
+  }, 15000);
+});

--- a/src/test/operations/walletItemTransfer/verifyWalletItemTransferPassword.spec.ts
+++ b/src/test/operations/walletItemTransfer/verifyWalletItemTransferPassword.spec.ts
@@ -1,0 +1,122 @@
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+
+import { BgNodeClient } from '../../../BgNodeClient.js';
+import chance from '../../../helpers/chance.js';
+import { MyUser } from '../../../models/MyUser.js';
+import updateWalletItemTransferPassword from '../../../operations/walletItemTransfer/updateWalletItemTransferPassword.js';
+import verifyWalletItemTransferPassword from '../../../operations/walletItemTransfer/verifyWalletItemTransferPassword.js';
+import clientStore from '../../helpers/clientStore.js';
+import { createPurchaseOrderSpecHelper } from '../../helpers/purchaseOrder/createPurchaseOrder.specHelper.js';
+import { deleteMyUserSpecHelper } from '../../helpers/user/deleteMyUser.specHelper.js';
+import { signMeUpSpecHelper } from '../../helpers/user/signMeUp.specHelper.js';
+import { findWalletItemsSpecHelper } from '../../helpers/walletItem/findWalletItems.specHelper.js';
+import { createWalletItemTransferSpecHelper } from '../../helpers/walletItemTransfer/createWalletItemTransfer.specHelper.js';
+
+describe('operations.walletItemTransfer.verifyWalletItemTransferPassword', () => {
+  let client: BgNodeClient;
+  let myUser: MyUser;
+  let testPassword: string;
+  let transferSecret: string;
+  let transferSlug: string;
+
+  beforeAll(async () => {
+    client = await clientStore.getTestClient();
+    myUser = await signMeUpSpecHelper(undefined, false, client);
+    transferSlug = chance.guid();
+    transferSecret = chance.integer({ min: 100000, max: 999999 }).toString();
+  });
+
+  afterAll(async () => {
+    await deleteMyUserSpecHelper(client);
+  });
+
+  test('should verify correct password successfully', async () => {
+    const itemCount = 1;
+    await createPurchaseOrderSpecHelper(
+      {},
+      itemCount,
+      [],
+      client,
+    );
+
+    const walletItems = await findWalletItemsSpecHelper(client, myUser, itemCount);
+    const walletItem = walletItems[0];
+
+    await createWalletItemTransferSpecHelper({
+      walletItemId: walletItem.id,
+      transferSlug,
+      transferSecret,
+      recipientFullName: chance.name(),
+      recipientEmail: chance.email(),
+      messageText: chance.sentence(),
+    }, client);
+
+    // Set a password first
+    testPassword = chance.string({ length: 8, alpha: true, numeric: true });
+
+    const updateResult = await updateWalletItemTransferPassword(
+      transferSlug,
+      transferSecret,
+      testPassword,
+    );
+
+    expect(updateResult.error).toBeUndefined();
+
+    // Now verify the password
+    const verifyResult = await verifyWalletItemTransferPassword(
+      transferSlug,
+      testPassword,
+    );
+
+    expect(verifyResult.error).toBeUndefined();
+    expect(verifyResult.object).toBe(true); //todo failing here
+  }, 20000);
+
+  test('should return false for incorrect password', async () => {
+    const incorrectPassword = chance.string({ length: 8, alpha: true, numeric: true });
+
+    const result = await verifyWalletItemTransferPassword(
+      transferSlug,
+      incorrectPassword,
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.object).toBe(false);
+  }, 10000);
+
+  test('should handle empty password verification', async () => {
+    const emptyPassword = '';
+
+    const result = await verifyWalletItemTransferPassword(
+      transferSlug,
+      emptyPassword,
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.object).toBe(false);
+  }, 10000);
+
+  test('should be case sensitive for password verification', async () => {
+    // Set a password with mixed case
+    const mixedCasePassword = 'TestPassword123';
+
+    const updateResult = await updateWalletItemTransferPassword(
+      transferSlug,
+      transferSecret,
+      mixedCasePassword,
+    );
+
+    expect(updateResult.error).toBeUndefined();
+
+    // Try to verify with different case
+    const wrongCasePassword = 'testpassword123';
+
+    const verifyResult = await verifyWalletItemTransferPassword(
+      transferSlug,
+      wrongCasePassword,
+    );
+
+    expect(verifyResult.error).toBeUndefined();
+    expect(verifyResult.object).toBe(false);
+  }, 20000);
+});

--- a/src/types/Operations.ts
+++ b/src/types/Operations.ts
@@ -504,6 +504,7 @@ export interface Operations {
 
     findWalletItemTransferRecipientInfoByTransferSlug: (
       transferSlug: string,
+      transferSecret?: string | null,
     ) => Promise<QueryResult<WalletItemTransferRecipientInfo>>;
 
     findWalletItemTransferById: (


### PR DESCRIPTION
The following wallet item transfer tests are added:
- findWalletItemTransferById
- findWalletItemTransferRecipientInfoByTransferSlug
- updateWalletItemTransfer
- updateWalletItemTransferPassword
- verfiyWalletItemTransferPassword (facing a single error I marked it as todo at the place of error)